### PR TITLE
Add `Pipfile` and `README`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+"discord.py" = {file = "https://github.com/Rapptz/discord.py/archive/rewrite.zip"}
+libchampmastery = {git = "https://github.com/HeavyLobster/libchampmastery"}
+
+[dev-packages]
+
+[requires]
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,27 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "6b984dc68552b77f435d7ab346053a4001c460ac44e7265f59109dd2c677834d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "discord.py": {
+            "file": "https://github.com/Rapptz/discord.py/archive/rewrite.zip"
+        },
+        "libchampmastery": {
+            "git": "https://github.com/HeavyLobster/libchampmastery"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Darb
+![avatar](https://cdn.discordapp.com/avatars/290324118665166849/c7c48c6b2754ba532a0455b331a47d9f.png)
+
+Darb is the Discord Bot used by the [Bardians](https://discord.gg/bardians)
+Discord server for assigning mastery roles and performing other League of
+Legends-related tasks on the server.
+
+
+## Setup
+- Install `pipenv`: `pip3 install pipenv`
+- Install dependencies: `pipenv install`
+
+
+## Disclaimer
+Darb isn't endorsed by Riot Games and doesn't reflect the views or opinions of Riot Games or anyone officially involved in producing or managing League of Legends. League of Legends and Riot Games are trademarks or registered trademarks of Riot Games, Inc. League of Legends © Riot Games, Inc.


### PR DESCRIPTION
This PR adds a `Pipfile` (and the accompanying `Pipfile.lock`) for dependency management and a `README.md` file including simple setup instructions. These only cover the dependency installation process so far, but having a simpler setup process through environment variables would be desirable.